### PR TITLE
Fix npm install on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "debug": "node dist/app.js --verbose --port=1338",
     "postinstall": "npm run build-prod",
     "build": "babel src --out-dir dist --copy-files",
-    "build-prod": "NODE_ENV=production babel src --out-dir dist --copy-files",
+    "build-prod": "NODE_ENV=production& SET NODE_ENV=production& babel src --out-dir dist --copy-files",
     "build-watch": "babel src --watch --out-dir dist --copy-files --ignore \"/assets/\""
   },
   "main": "/dist/app.js",


### PR DESCRIPTION
Currently, master fails to `npm install` on windows. Modified `build-prod` npm script to set NODE_ENV in either windows or unix. Will print warning on unix due to the new windows command, but `npm install` succeeds.

Following is the output from running `npm install` on windows:

> $ npm install
> npm WARN deprecated npmconf@2.1.2: this package has been reintegrated into npm and is now out of date with re                                                                                                                                                                  spect to npm
> npm WARN deprecated lodash@2.4.1: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
> npm WARN deprecated graceful-fs@3.0.8: graceful-fs v3.0.0 and before will fail on node releases >= v6.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the t                                                                 ree.
> npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v6.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the t                                                                 ree.
> npm WARN deprecated grunt-lib-contrib@0.7.1: DEPRECATED. See readme: https://github.com/gruntjs/grunt-lib-contrib
> npm WARN deprecated lodash@1.0.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
> npm WARN deprecated native-or-bluebird@1.1.2: 'native-or-bluebird' is deprecated. Please use 'any-promise' instead.
> 
> > typechecker@2.0.8 preinstall C:\Users\Dan\Code\sails-universal-react-starter\node_modules.staging\typechecker-98f6e0bc
> > node ./cyclic.js
> > 
> > typechecker@2.0.8 preinstall C:\Users\Dan\Code\sails-universal-react-starter\node_modules.staging\typechecker-6670b609
> > node ./cyclic.js
> > 
> > sails@0.12.3 preinstall C:\Users\Dan\Code\sails-universal-react-starter\node_modules.staging\sails-da554484
> > node ./lib/preinstall_npmcheck.js
> 
> Sails.js Installation: Checking npm-version successful
> npm WARN prefer global jsonlint-lines@1.6.0 should be installed with -g
> npm WARN prefer global grunt-cli@0.1.13 should be installed with -g
> npm WARN prefer global node-gyp@3.3.1 should be installed with -g
> 
> > node-sass@3.6.0 install C:\Users\Dan\Code\sails-universal-react-starter\node_modules\node-sass
> > node scripts/install.js
> 
> Binary downloaded and installed at C:\Users\Dan\Code\sails-universal-react-starter\node_modules\node-sass\vendor\win32-x64-46\binding.node
> 
> > node-sass@3.6.0 postinstall C:\Users\Dan\Code\sails-universal-react-starter\node_modules\node-sass
> > node scripts/build.js
> 
> "C:\Users\Dan\Code\sails-universal-react-starter\node_modules\node-sass\vendor\win32-x64-46\binding.node" exists.
>  testing binary.
> Binary is fine; exiting.
> 
> > sails-universal-react-starter@0.0.0 postinstall C:\Users\Dan\Code\sails-universal-react-starter
> > npm run build-prod
> > 
> > sails-universal-react-starter@0.0.0 build-prod C:\Users\Dan\Code\sails-universal-react-starter
> > NODE_ENV=production babel src --out-dir dist --copy-files
> 
> 'NODE_ENV' is not recognized as an internal or external command,
> operable program or batch file.
> 
> npm ERR! Windows_NT 10.0.10586
> npm ERR! argv "C:\Program Files (x86)\nodejs\node.exe" "C:\Users\Dan\AppData\Roaming\npm\node_modules\npm\bin\npm-cli.js" "run" "build-prod"
> npm ERR! node v4.4.3
> npm ERR! npm  v3.8.8
> npm ERR! code ELIFECYCLE
> npm ERR! sails-universal-react-starter@0.0.0 build-prod: `NODE_ENV=production babel src --out-dir dist --copy-files`
> npm ERR! Exit status 1
> npm ERR!
> npm ERR! Failed at the sails-universal-react-starter@0.0.0 build-prod script 'NODE_ENV=production babel src --out-dir dist --copy-files'.
> npm ERR! Make sure you have the latest version of node.js and npm installed.
> npm ERR! If you do, this is most likely a problem with the sails-universal-react-starter package,
> npm ERR! not with npm itself.
> npm ERR! Tell the author that this fails on your system:
> npm ERR!     NODE_ENV=production babel src --out-dir dist --copy-files
> npm ERR! You can get information on how to open an issue for this project with:
> npm ERR!     npm bugs sails-universal-react-starter
> npm ERR! Or if that isn't available, you can get their info via:
> npm ERR!     npm owner ls sails-universal-react-starter
> npm ERR! There is likely additional logging output above.
> 
> npm ERR! Please include the following file with any support request:
> npm ERR!     C:\Users\Dan\Code\sails-universal-react-starter\npm-debug.log
> 
> npm WARN optional Skipping failed optional dependency /chokidar/fsevents:
> npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.12
> npm WARN eslint-config-airbnb@7.0.0 requires a peer of eslint-plugin-react@^4.3.0 but none was installed.
> npm ERR! Windows_NT 10.0.10586
> npm ERR! argv "C:\Program Files (x86)\nodejs\node.exe" "C:\Users\Dan\AppData\Roaming\npm\node_modules\npm\bin\npm-cli.js" "install"
> npm ERR! node v4.4.3
> npm ERR! npm  v3.8.8
> npm ERR! code ELIFECYCLE
> npm ERR! sails-universal-react-starter@0.0.0 postinstall: `npm run build-prod`
> npm ERR! Exit status 1
> npm ERR!
> npm ERR! Failed at the sails-universal-react-starter@0.0.0 postinstall script 'npm run build-prod'.
> npm ERR! Make sure you have the latest version of node.js and npm installed.
> npm ERR! If you do, this is most likely a problem with the sails-universal-react-starter package,
> npm ERR! not with npm itself.
> npm ERR! Tell the author that this fails on your system:
> npm ERR!     npm run build-prod
> npm ERR! You can get information on how to open an issue for this project with:
> npm ERR!     npm bugs sails-universal-react-starter
> npm ERR! Or if that isn't available, you can get their info via:
> npm ERR!     npm owner ls sails-universal-react-starter
> npm ERR! There is likely additional logging output above.
> 
> npm ERR! Please include the following file with any support request:
> npm ERR!     C:\Users\Dan\Code\sails-universal-react-starter\npm-debug.log
