### PR TITLE
Fix npm start on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "sails-hook-react-router": "^0.1.2",
     "sails-hook-webpack": "^2.0.3",
     "sass-loader": "^3.2.0",
+    "slash": "^1.0.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.15",
     "webpack-dev-server": "^1.14.1",

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ require('babel-polyfill');
 // this assumes your build directory is /dist
 import Module from 'module';
 import Path from 'path';
+import slash from 'slash';
 
 const originalRequire = Module.prototype.require;
 const originalResolve = Path.resolve;
@@ -35,7 +36,7 @@ if (!console.debug) {
 // override resolve to intercept invalid sails node_module paths
 Path.resolve = function resolve(...args) {
   if (args.length >= 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {
-    if (args[0].endsWith('/dist') && args[1] === 'node_modules') {
+    if (slash(args[0]).endsWith('/dist') && args[1] === 'node_modules') {
       args[1] = './../node_modules'; // force resolve to go up one dir
     }
   }


### PR DESCRIPTION
Currently, master fails to `npm start` on windows. Modified `src/app.js` to use the `slash` npm package for normalizing windows file paths to convert backslashes to foreward slashes before comparing against `'/dist'`.

Following is the output from running `npm start` on windows:

$ npm start

> > sails-universal-react-starter@0.0.0 start C:\Users\Dan\Code\sails-universal-react-starter
> > node dist/app.js --port=1338
> 
> info: Could not find module: ejs in path: C:\Users\Dan\Code\sails-universal-react-starter\dist\node_modules
> error: A hook (`orm`) failed to load!
> error: Error: Trying to use an unrecognized adapter, `sails-disk, in datastore`localDiskDb`.
> This may or may not be a real adapter available on NPM, but in any case it looks like`sails-disk`is not installed in this app
> (at least it is not in the expected path within the local`node_modules/` directory).
> 
> To attempt to install this adapter, run:
> `npm install sails-disk --save
>     at constructError (C:\Users\Dan\Code\sails-universal-react-starter\node_modules\sails-hook-orm\lib\construct-error.js:57:13)
>     at loadAdapterFromAppDependencies (C:\Users\Dan\Code\sails-universal-react-starter\node_modules\sails-hook-orm\lib\load-adapter-from-app-dependencies.js:59:13)
>     at _eachRelevantDatastoreIdentity (C:\Users\Dan\Code\sails-universal-react-starter\node_modules\sails-hook-orm\lib\initialize.js:141:56)
>     at arrayEach (C:\Users\Dan\Code\sails-universal-react-starter\node_modules\lodash\index.js:1289:13)
>     at Function.<anonymous> (C:\Users\Dan\Code\sails-universal-react-starter\node_modules\lodash\index.js:3345:13)
>     at Array.async.auto._attemptToLoadUnrecognizedAdapters (C:\Users\Dan\Code\sails-universal-react-starter\node_modules\sails-hook-orm\lib\initialize.js:130:11)
>     at listener (C:\Users\Dan\Code\sails-universal-react-starter\node_modules\async\lib\async.js:605:42)
>     at C:\Users\Dan\Code\sails-universal-react-starter\node_modules\async\lib\async.js:544:17
>     at _arrayEach (C:\Users\Dan\Code\sails-universal-react-starter\node_modules\async\lib\async.js:85:13)
>     at Immediate.taskComplete (C:\Users\Dan\Code\sails-universal-react-starter\node_modules\async\lib\async.js:543:13)
>     at processImmediate [as _immediateCallback] (timers.js:383:17) { [Error: Trying to use an unrecognized adapter,`sails-disk, in datastore `localDiskDb`.
> This may or may not be a real adapter available on NPM, but in any case it looks like `sails-disk` is not installed in this app
> (at least it is not in the expected path within the local `node_modules/` directory).
> 
> To attempt to install this adapter, run:
> `npm install sails-disk --save] code: 'E_ADAPTER_NOT_INSTALLED' }
